### PR TITLE
Make .travis.yml simpler by specifying "node_js" field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: node_js
 sudo: false
+node_js:
+  - "8.4.0"
 cache:
   directories:
     - node_modules
-env:
-  - NODE_VERSION="8.4.0"
-before_install:
-  - git clone https://github.com/creationix/nvm.git /tmp/.nvm
-  - source /tmp/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - nvm use --delete-prefix $NODE_VERSION
-  - node --version
 install:
   - npm install
 script:


### PR DESCRIPTION
## What I did
* Make .travis.yml simpler

I just used `node_js: - "8.4.0"` instead of `NODE_VERSION="8.4.0"` and `nvm install $NODE_VERSION`.
The build status was successful: <https://travis-ci.com/nwtgck/electron_clipfmt>.
- - - 
In addition, you can easily add additional node versions like the following and they will be built parallelly!

```yml
node_js:
  - "8.4.0"
  - "9"
  - "10"
```